### PR TITLE
fix: improve error messages and update template dependencies

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -17,7 +17,9 @@
   },
   "files": [
     "dist",
-    "templates"
+    "templates",
+    "registry",
+    "components"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -77,10 +77,10 @@ export async function init(options: InitOptions) {
         format: 'biome format --write .',
       },
       devDependencies: {
-        '@biomejs/biome': '^1.8.3',
-        vite: '^5.3.0',
+        '@biomejs/biome': '^2.1.1',
+        vite: '^6.0.7',
         ...(useTypescript && {
-          typescript: '^5.5.0',
+          typescript: '^5.7.3',
           '@types/kintone-js-sdk': '^1.0.0',
         }),
       },
@@ -90,7 +90,7 @@ export async function init(options: InitOptions) {
 
     // Create biome.json
     const biomeConfig = {
-      $schema: 'https://biomejs.dev/schemas/1.8.3/schema.json',
+      $schema: 'https://biomejs.dev/schemas/2.1.1/schema.json',
       organizeImports: {
         enabled: true,
       },

--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -37,8 +37,14 @@ export async function list(options: ListOptions) {
       logger.break()
     }
   } catch (error) {
-    logger.error('Failed to list components')
-    console.error(error)
+    if (error instanceof Error && error.message.includes('ENOENT')) {
+      logger.error('Failed to load component registry.')
+      logger.info('This might be due to a corrupted installation. Please try reinstalling:')
+      logger.info('  pnpm dlx k5e-cn@latest list')
+    } else {
+      logger.error('Failed to list components')
+      logger.info(`Error details: ${error instanceof Error ? error.message : String(error)}`)
+    }
     process.exit(1)
   }
 }


### PR DESCRIPTION
## Summary
- Fix issue #5: Add better error message for missing registry file
- Fix issue #4: Update template dependencies to latest versions
- Add registry and components directories to npm package files

## Changes

### Issue #5 - Improved error messages
- Added specific error handling for missing registry file
- Provides helpful reinstall instructions when registry is missing

### Issue #4 - Updated template dependencies
- Biome: 1.8.3 → 2.1.1
- Vite: 5.3.0 → 6.0.7
- TypeScript: 5.5.0 → 5.7.3

### NPM package fix
- Added `registry` and `components` directories to `files` in package.json

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Type check passes (`pnpm typecheck`)
- [ ] Test `pnpm dlx k5e-cn@latest list` after publishing
- [ ] Test `pnpm dlx k5e-cn@latest init` creates project with updated dependencies

Fixes #5
Fixes #4