### PR TITLE
fix: correct biome command and remove non-existent TypeScript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "pnpm -r build",
     "dev": "pnpm -r dev",
     "lint": "biome check .",
-    "lint:fix": "biome check --apply .",
+    "lint:fix": "biome check --write .",
     "format": "biome format --write .",
     "format:check": "biome format .",
     "typecheck": "pnpm -r typecheck",

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -73,7 +73,7 @@ export async function init(options: InitOptions) {
         dev: 'vite',
         preview: 'vite preview',
         lint: 'biome check .',
-        'lint:fix': 'biome check --apply .',
+        'lint:fix': 'biome check --write .',
         format: 'biome format --write .',
       },
       devDependencies: {
@@ -81,7 +81,6 @@ export async function init(options: InitOptions) {
         vite: '^6.0.7',
         ...(useTypescript && {
           typescript: '^5.7.3',
-          '@types/kintone-js-sdk': '^1.0.0',
         }),
       },
     }


### PR DESCRIPTION
## Summary
- Fixed biome lint:fix command to use `--write` instead of `--apply` (Biome v2 syntax)
- Removed non-existent `@types/kintone-js-sdk` dependency from TypeScript project initialization
- Updated both root package.json and CLI template generation code

## Related Issues
- Fixes #8 (initしたpjのbiomeのcommandがおかしい？)
- Fixes #7 (initしたpjでpnpm installに失敗する)

## Test Plan
- [ ] Run `pnpm dlx k5e-cn@latest init` to create a new project
- [ ] Verify `pnpm install` completes successfully in the new project
- [ ] Verify `pnpm lint:fix` runs without errors in the new project